### PR TITLE
fix: add collection: true to mixed content attributes

### DIFF
--- a/lib/rfcxml/v3/annotation.rb
+++ b/lib/rfcxml/v3/annotation.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Annotation < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bcp14, Bcp14, collection: true
       attribute :cref, Cref, collection: true
       attribute :em, Em, collection: true

--- a/lib/rfcxml/v3/dd.rb
+++ b/lib/rfcxml/v3/dd.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Dd < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :pn, :string
       attribute :artset, Artset, collection: true

--- a/lib/rfcxml/v3/li.rb
+++ b/lib/rfcxml/v3/li.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Li < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :pn, :string
       attribute :artset, Artset, collection: true

--- a/lib/rfcxml/v3/name.rb
+++ b/lib/rfcxml/v3/name.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Name < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :slugified_name, :string
       attribute :bcp14, Bcp14, collection: true
       attribute :br, Br, collection: true

--- a/lib/rfcxml/v3/organization.rb
+++ b/lib/rfcxml/v3/organization.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Organization < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :abbrev, :string
       attribute :ascii, :string
       attribute :ascii_abbrev, :string

--- a/lib/rfcxml/v3/sourcecode.rb
+++ b/lib/rfcxml/v3/sourcecode.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Sourcecode < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :pn, :string
       attribute :name, :string

--- a/lib/rfcxml/v3/td.rb
+++ b/lib/rfcxml/v3/td.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Td < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :colspan, :string
       attribute :rowspan, :string

--- a/lib/rfcxml/v3/text.rb
+++ b/lib/rfcxml/v3/text.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Text < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :pn, :string
       attribute :hang_text, :string

--- a/lib/rfcxml/v3/xref.rb
+++ b/lib/rfcxml/v3/xref.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Xref < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :target, :string
       attribute :pageno, :string, default: -> { "false" }
       attribute :format, :string, default: -> { "default" }


### PR DESCRIPTION
## Summary
- Add `collection: true` to all `map_content` attributes used with `mixed_content`
- Required by lutaml-model `MixedContentCollectionError` validation (lutaml/lutaml-model#647)

## Why
When `mixed_content` is enabled with `map_content`, the content attribute must be a string collection to properly handle multiple interleaved text nodes in XML. Without `collection: true`, text nodes beyond the first are silently dropped during deserialization.

## Affected models
- `Rfcxml::V3::Organization`, `Xref`, `Sourcecode`, `Text`, `Name`, `Annotation`, `Dd`, `Li`, `Td`