### PR TITLE
fix: use mixed_content instead of ordered with map_content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 Gemfile.lock
 TODO*
+.claude/worktrees/

--- a/lib/rfcxml/v3/blockquote.rb
+++ b/lib/rfcxml/v3/blockquote.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Blockquote < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :pn, :string
       attribute :cite, :string
@@ -34,7 +34,7 @@ module Rfcxml
 
       xml do
         element "blockquote"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "anchor", to: :anchor

--- a/lib/rfcxml/v3/c.rb
+++ b/lib/rfcxml/v3/c.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class C < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :cref, Cref, collection: true
       attribute :eref, Eref, collection: true
       attribute :iref, Iref, collection: true
@@ -14,7 +14,7 @@ module Rfcxml
 
       xml do
         element "c"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "cref", to: :cref

--- a/lib/rfcxml/v3/cref.rb
+++ b/lib/rfcxml/v3/cref.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Cref < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :source, :string
       attribute :display, :string, default: -> { "true" }
@@ -21,7 +21,7 @@ module Rfcxml
 
       xml do
         element "cref"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "anchor", to: :anchor

--- a/lib/rfcxml/v3/dt.rb
+++ b/lib/rfcxml/v3/dt.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Dt < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :anchor, :string
       attribute :pn, :string
       attribute :bcp14, Bcp14, collection: true
@@ -23,7 +23,7 @@ module Rfcxml
 
       xml do
         element "dt"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_attribute "anchor", to: :anchor

--- a/lib/rfcxml/v3/postamble.rb
+++ b/lib/rfcxml/v3/postamble.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Postamble < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :cref, Cref, collection: true
       attribute :eref, Eref, collection: true
       attribute :iref, Iref, collection: true
@@ -14,7 +14,7 @@ module Rfcxml
 
       xml do
         element "postamble"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "cref", to: :cref

--- a/lib/rfcxml/v3/preamble.rb
+++ b/lib/rfcxml/v3/preamble.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Preamble < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bcp14, Bcp14, collection: true
       attribute :cref, Cref, collection: true
       attribute :em, Em, collection: true
@@ -22,7 +22,7 @@ module Rfcxml
 
       xml do
         element "preamble"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "bcp14", to: :bcp14

--- a/lib/rfcxml/v3/refcontent.rb
+++ b/lib/rfcxml/v3/refcontent.rb
@@ -5,13 +5,13 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Refcontent < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bcp14, Bcp14, collection: true
       include XrefText
 
       xml do
         element "refcontent"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "bcp14", to: :bcp14

--- a/lib/rfcxml/v3/strong.rb
+++ b/lib/rfcxml/v3/strong.rb
@@ -4,7 +4,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Strong < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bcp14, Bcp14, collection: true
       attribute :br, Br, collection: true
       attribute :cref, Cref, collection: true
@@ -19,7 +19,7 @@ module Rfcxml
 
       xml do
         element "strong"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "bcp14", to: :bcp14

--- a/lib/rfcxml/v3/sub.rb
+++ b/lib/rfcxml/v3/sub.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rfcxml
   module V3
     class Sub < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :string, collection: true
       attribute :bcp14, Bcp14, collection: true
       attribute :cref, Cref, collection: true
       attribute :em, "Rfcxml::V3::Em", collection: true
@@ -20,7 +20,7 @@ module Rfcxml
 
       xml do
         element "sub"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "bcp14", to: :bcp14

--- a/lib/rfcxml/v3/sup.rb
+++ b/lib/rfcxml/v3/sup.rb
@@ -7,7 +7,7 @@ module Rfcxml
     class Sup < Sub
       xml do
         element "sup"
-        ordered
+        mixed_content
 
         map_content to: :content
         map_element "bcp14", to: :bcp14

--- a/spec/v3/cref_spec.rb
+++ b/spec/v3/cref_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Rfcxml::V3::Cref do
       expect(cref.source).to eq("editor")
       expect(cref.strong.size).to eq(1)
       expect(cref.tt.size).to eq(1)
-      expect(cref.strong.first.content).to eq("MUST")
+      expect(cref.strong.first.content).to eq(["MUST"])
       expect(cref.tt.first.content).to eq("code")
     end
 


### PR DESCRIPTION
lutaml-model now raises `OrderedContentMappingError` when `ordered` content model is used with `map_content`. Mixed content is the correct content model for elements that have both text and child elements.

Changes:
- Replace `ordered` with `mixed_content` in 10 files that use `map_content`
- Change `:content` attribute to `collection: true` (required by `mixed_content` + `map_content`)
- Update spec expectation for `Strong#content` (now array instead of string)

Depends on: lutaml/lutaml-model#677