### PR TITLE
fix(ci): use rsync to fetch RFC XML after rfc-editor.org retired the bulk tarball

### DIFF
--- a/.github/workflows/roundtrip.yml
+++ b/.github/workflows/roundtrip.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -45,15 +45,15 @@ jobs:
       - name: Download RFC XML files
         run: |
           mkdir -p rfc-xml-source
-          echo "Downloading RFC XML tarball..."
-          curl -L -o xmlsource.tar.gz "https://www.rfc-editor.org/in-notes/tar/xmlsource-all.tar.gz"
-          echo "Extracting..."
-          tar -xzf xmlsource.tar.gz -C rfc-xml-source
-          # The tarball extracts to a subdirectory, find it
-          XML_DIR=$(find rfc-xml-source -name "*.xml" -type f | head -1 | xargs dirname)
-          echo "XML_DIR=$XML_DIR" >> $GITHUB_ENV
-          FILE_COUNT=$(find "$XML_DIR" -name "*.xml" -type f | wc -l)
-          echo "Found $FILE_COUNT XML files in $XML_DIR"
+          echo "Syncing published RFC XML files via rsync..."
+          # rfc-editor.org retired the bulk tarball; rsync is now the official source.
+          # --include='*.xml' --exclude='*' (without --include='*/') limits the transfer
+          # to XML files at the module root, which are the published RFCs.
+          rsync -az --include='*.xml' --exclude='*' \
+            rsync.rfc-editor.org::rfcs/ rfc-xml-source/
+          echo "XML_DIR=rfc-xml-source" >> $GITHUB_ENV
+          FILE_COUNT=$(find "$XML_DIR" -maxdepth 1 -name "*.xml" -type f | wc -l)
+          echo "Found $FILE_COUNT published RFC XML files in $XML_DIR"
 
       - name: Run round-trip tests
         run: |
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: roundtrip-results
           path: tmp/roundtrip-results-*/


### PR DESCRIPTION
## Problem

The 'RFC Round-Trip Tests' workflow has been failing at the 'Download RFC XML files' step (exit code 2) — see [run #37](https://github.com/metanorma/rfcxml/actions/runs/27484206951/job/81237260584).

Root cause: `https://www.rfc-editor.org/in-notes/tar/xmlsource-all.tar.gz` now returns 404. rfc-editor.org retired the bulk HTTP tarball; rsync is now the only bulk download method documented at https://www.rfc-editor.org/series/rfc-download/.

curl silently saved the 404 HTML body as `xmlsource.tar.gz`, then `tar -xzf` exited 2 on the invalid gzip.

## Fix

Replace `curl + tar` with rsync from the `rfcs` module:

```bash
rsync -az --include='*.xml' --exclude='*' rsync.rfc-editor.org::rfcs/ rfc-xml-source/
```

- The filter (no `--include='*/'`) pulls only the ~1314 published RFC XML files at the module root and excludes the ~1308 unprocessed `prerelease/*.notprepped.xml` drafts — matching the original tarball's content.
- Files land flat in `rfc-xml-source/`, which is what `scripts/roundtrip_test.rb`'s directory glob expects.

Also bumps `actions/checkout@v4 → v6` and `actions/upload-artifact@v4 → v7` to clear the Node.js 20 deprecation warnings (forced Node.js 24 defaults begin 2026-06-16).

## Verification

- rsync locally pulls 1314 published RFC XMLs flat into the destination.
- 3-file and 15-file random samples pass 100% through the round-trip script.
- YAML parses cleanly.