### PR TITLE
feat: add RfcIndex model + fix Artwork src and Dd blockquote round-trips

### DIFF
--- a/lib/rfcxml.rb
+++ b/lib/rfcxml.rb
@@ -14,3 +14,4 @@ module Rfcxml
 end
 
 require_relative "rfcxml/v3"
+require_relative "rfcxml/rfc_index"

--- a/lib/rfcxml/rfc_index.rb
+++ b/lib/rfcxml/rfc_index.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Rfcxml
+  module RfcIndex
+    autoload :Namespace, "#{__dir__}/rfc_index/namespace"
+    autoload :RfcIndex, "#{__dir__}/rfc_index/rfc_index"
+    autoload :RfcEntry, "#{__dir__}/rfc_index/rfc_entry"
+    autoload :StdEntry, "#{__dir__}/rfc_index/std_entry"
+    autoload :BcpEntry, "#{__dir__}/rfc_index/bcp_entry"
+    autoload :FyiEntry, "#{__dir__}/rfc_index/fyi_entry"
+    autoload :RfcNotIssuedEntry, "#{__dir__}/rfc_index/rfc_not_issued_entry"
+    autoload :Author, "#{__dir__}/rfc_index/author"
+    autoload :Date, "#{__dir__}/rfc_index/date"
+    autoload :Format, "#{__dir__}/rfc_index/format"
+    autoload :Keywords, "#{__dir__}/rfc_index/keywords"
+    autoload :Kw, "#{__dir__}/rfc_index/kw"
+    autoload :Abstract, "#{__dir__}/rfc_index/abstract"
+    autoload :DocumentRef, "#{__dir__}/rfc_index/document_ref"
+  end
+end

--- a/lib/rfcxml/rfc_index/abstract.rb
+++ b/lib/rfcxml/rfc_index/abstract.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class Abstract < Lutaml::Model::Serializable
+      attribute :p, :string, collection: true
+
+      xml do
+        root "abstract"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "p", to: :p
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/author.rb
+++ b/lib/rfcxml/rfc_index/author.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class Author < Lutaml::Model::Serializable
+      attribute :name, :string
+      attribute :title, :string
+      attribute :organization, :string
+      attribute :org_abbrev, :string
+
+      xml do
+        root "author"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "name", to: :name
+        map_element "title", to: :title
+        map_element "organization", to: :organization
+        map_element "org-abbrev", to: :org_abbrev
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/bcp_entry.rb
+++ b/lib/rfcxml/rfc_index/bcp_entry.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+require_relative "document_ref"
+
+module Rfcxml
+  module RfcIndex
+    class BcpEntry < Lutaml::Model::Serializable
+      attribute :doc_id, :string
+      attribute :title, :string
+      attribute :is_also, DocumentRef
+
+      xml do
+        root "bcp-entry"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "doc-id", to: :doc_id
+        map_element "title", to: :title
+        map_element "is-also", to: :is_also
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/date.rb
+++ b/lib/rfcxml/rfc_index/date.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class Date < Lutaml::Model::Serializable
+      attribute :month, :string
+      attribute :day, :string
+      attribute :year, :string
+
+      xml do
+        root "date"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "month", to: :month
+        map_element "day", to: :day
+        map_element "year", to: :year
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/document_ref.rb
+++ b/lib/rfcxml/rfc_index/document_ref.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class DocumentRef < Lutaml::Model::Serializable
+      attribute :doc_id, :string, collection: true
+
+      xml do
+        root "documentRef"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "doc-id", to: :doc_id
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/format.rb
+++ b/lib/rfcxml/rfc_index/format.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class Format < Lutaml::Model::Serializable
+      attribute :file_format, :string, collection: true
+
+      xml do
+        root "format"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "file-format", to: :file_format
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/fyi_entry.rb
+++ b/lib/rfcxml/rfc_index/fyi_entry.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+require_relative "document_ref"
+
+module Rfcxml
+  module RfcIndex
+    class FyiEntry < Lutaml::Model::Serializable
+      attribute :doc_id, :string
+      attribute :title, :string
+      attribute :is_also, DocumentRef
+
+      xml do
+        root "fyi-entry"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "doc-id", to: :doc_id
+        map_element "title", to: :title
+        map_element "is-also", to: :is_also
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/keywords.rb
+++ b/lib/rfcxml/rfc_index/keywords.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+require_relative "kw"
+
+module Rfcxml
+  module RfcIndex
+    class Keywords < Lutaml::Model::Serializable
+      attribute :kw, Kw, collection: true
+
+      xml do
+        root "keywords"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "kw", to: :kw
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/kw.rb
+++ b/lib/rfcxml/rfc_index/kw.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class Kw < Lutaml::Model::Serializable
+      attribute :content, :string
+
+      xml do
+        root "kw"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_content to: :content
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/namespace.rb
+++ b/lib/rfcxml/rfc_index/namespace.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "lutaml/xml"
+
+module Rfcxml
+  module RfcIndex
+    class Namespace < Lutaml::Xml::W3c::XmlNamespace
+      uri "https://www.rfc-editor.org/rfc-index"
+      element_form_default :qualified
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/rfc_entry.rb
+++ b/lib/rfcxml/rfc_index/rfc_entry.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+require_relative "author"
+require_relative "date"
+require_relative "format"
+require_relative "keywords"
+require_relative "abstract"
+require_relative "document_ref"
+
+module Rfcxml
+  module RfcIndex
+    class RfcEntry < Lutaml::Model::Serializable
+      attribute :doc_id, :string
+      attribute :title, :string
+      attribute :author, Author, collection: true
+      attribute :date, Date
+      attribute :format, Format
+      attribute :page_count, :string
+      attribute :keywords, Keywords
+      attribute :abstract, Abstract
+      attribute :draft, :string
+      attribute :notes, :string
+      attribute :obsoletes, DocumentRef
+      attribute :obsoleted_by, DocumentRef
+      attribute :updates, DocumentRef
+      attribute :updated_by, DocumentRef
+      attribute :is_also, DocumentRef
+      attribute :see_also, DocumentRef
+      attribute :current_status, :string
+      attribute :publication_status, :string
+      attribute :stream, :string
+      attribute :area, :string
+      attribute :wg_acronym, :string
+      attribute :errata_url, :string
+      attribute :doi, :string
+
+      xml do
+        root "rfc-entry"
+        namespace Rfcxml::RfcIndex::Namespace
+        ordered
+
+        map_element "doc-id", to: :doc_id
+        map_element "title", to: :title
+        map_element "author", to: :author
+        map_element "date", to: :date
+        map_element "format", to: :format
+        map_element "page-count", to: :page_count
+        map_element "keywords", to: :keywords
+        map_element "abstract", to: :abstract
+        map_element "draft", to: :draft
+        map_element "notes", to: :notes
+        map_element "obsoletes", to: :obsoletes
+        map_element "obsoleted-by", to: :obsoleted_by
+        map_element "updates", to: :updates
+        map_element "updated-by", to: :updated_by
+        map_element "is-also", to: :is_also
+        map_element "see-also", to: :see_also
+        map_element "current-status", to: :current_status
+        map_element "publication-status", to: :publication_status
+        map_element "stream", to: :stream
+        map_element "area", to: :area
+        map_element "wg_acronym", to: :wg_acronym
+        map_element "errata-url", to: :errata_url
+        map_element "doi", to: :doi
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/rfc_index.rb
+++ b/lib/rfcxml/rfc_index/rfc_index.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+require_relative "namespace"
+require_relative "bcp_entry"
+require_relative "fyi_entry"
+require_relative "rfc_entry"
+require_relative "rfc_not_issued_entry"
+require_relative "std_entry"
+
+module Rfcxml
+  module RfcIndex
+    class RfcIndex < Lutaml::Model::Serializable
+      attribute :title, :string
+      attribute :bcp_entry, BcpEntry, collection: true
+      attribute :fyi_entry, FyiEntry, collection: true
+      attribute :rfc_entry, RfcEntry, collection: true
+      attribute :rfc_not_issued_entry, RfcNotIssuedEntry, collection: true
+      attribute :std_entry, StdEntry, collection: true
+
+      xml do
+        root "rfc-index"
+        namespace Rfcxml::RfcIndex::Namespace
+        ordered
+
+        map_attribute "title", to: :title
+
+        map_element "bcp-entry", to: :bcp_entry
+        map_element "fyi-entry", to: :fyi_entry
+        map_element "rfc-entry", to: :rfc_entry
+        map_element "rfc-not-issued-entry", to: :rfc_not_issued_entry
+        map_element "std-entry", to: :std_entry
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/rfc_not_issued_entry.rb
+++ b/lib/rfcxml/rfc_index/rfc_not_issued_entry.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Rfcxml
+  module RfcIndex
+    class RfcNotIssuedEntry < Lutaml::Model::Serializable
+      attribute :doc_id, :string
+
+      xml do
+        root "rfc-not-issued-entry"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "doc-id", to: :doc_id
+      end
+    end
+  end
+end

--- a/lib/rfcxml/rfc_index/std_entry.rb
+++ b/lib/rfcxml/rfc_index/std_entry.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+require_relative "document_ref"
+
+module Rfcxml
+  module RfcIndex
+    class StdEntry < Lutaml::Model::Serializable
+      attribute :doc_id, :string
+      attribute :title, :string
+      attribute :is_also, DocumentRef
+
+      xml do
+        root "std-entry"
+        namespace Rfcxml::RfcIndex::Namespace
+
+        map_element "doc-id", to: :doc_id
+        map_element "title", to: :title
+        map_element "is-also", to: :is_also
+      end
+    end
+  end
+end

--- a/lib/rfcxml/v3/artwork.rb
+++ b/lib/rfcxml/v3/artwork.rb
@@ -27,13 +27,14 @@ module Rfcxml
         map_attribute "pn", to: :pn
         map_attribute "name", to: :name, value_map: { to: { empty: :empty } }
         map_attribute "type", to: :type, value_map: { to: { empty: :empty } }
-        map_attribute "src", to: :src
+        map_attribute "src", to: :src, value_map: { to: { empty: :empty } }
         map_attribute "align", to: :align
         map_attribute "alt", to: :alt, value_map: { to: { empty: :empty } }
         map_attribute "width", to: :width, value_map: { to: { empty: :empty } }
         map_attribute "height", to: :height,
                                 value_map: { to: { empty: :empty } }
-        map_attribute "originalSrc", to: :original_src
+        map_attribute "originalSrc", to: :original_src,
+                                     value_map: { to: { empty: :empty } }
       end
     end
   end

--- a/lib/rfcxml/v3/dd.rb
+++ b/lib/rfcxml/v3/dd.rb
@@ -10,6 +10,7 @@ module Rfcxml
       attribute :pn, :string
       attribute :artset, Artset, collection: true
       attribute :artwork, Artwork, collection: true
+      attribute :blockquote, Blockquote, collection: true
       attribute :dl, Dl, collection: true
       attribute :figure, Figure, collection: true
       attribute :ol, Ol, collection: true
@@ -41,8 +42,9 @@ module Rfcxml
         map_attribute "anchor", to: :anchor
         map_attribute "pn", to: :pn
 
-        %w[artset artwork aside dl figure ol sourcecode t table ul bcp14 br
-           cref em eref iref relref strong sub sup tt u xref].each do |element|
+        %w[artset artwork blockquote aside dl figure ol sourcecode t table ul
+           bcp14 br cref em eref iref relref strong sub sup tt u
+           xref].each do |element|
           map_element element, to: element.to_sym
         end
       end

--- a/scripts/roundtrip_test.rb
+++ b/scripts/roundtrip_test.rb
@@ -120,63 +120,82 @@ class RoundTripTester
     end
   end
 
+  def root_element_name(xml)
+    xml.each_line do |line|
+      if (m = line.match(/<([\w:.-]+)[\s>]/))
+        next if m[1] == "xml"
+
+        return m[1].sub(/^.*:/, "")
+      end
+    end
+    nil
+  end
+
   def perform_test(filepath, basename)
-    # Read input
-    input = begin
-      File.read(filepath)
-    rescue StandardError => e
-      return build_error_result(basename, "Read", e)
-    end
+    input = read_input(filepath, basename)
+    return input if input.key?(:status)
 
-    # Parse
-    parsed = begin
-      Rfcxml::V3::Rfc.from_xml(input)
-    rescue StandardError => e
-      return build_error_result(basename, "Parse", e)
-    end
+    parsed = parse_input(input[:xml], basename)
+    return parsed if parsed.key?(:status)
 
-    # Serialize
-    output = begin
-      parsed.to_xml(pretty: true, declaration: true, encoding: "utf-8")
-    rescue StandardError => e
-      return build_error_result(basename, "Serialize", e)
-    end
+    output = serialize(parsed[:model], basename)
+    return output if output.key?(:status)
 
-    # Compare using Canon DOM diff with explicit match options
-    # Using DOM diff with attribute_order: ignore and attribute_values: normalize
-    # handles round-trip differences correctly
-    comparison = begin
-      Canon::Comparison.equivalent?(
-        output,
-        input,
-        diff_algorithm: :dom,
-        format: :xml,
-        match: {
-          attribute_order: :ignore,
-          attribute_values: :normalize,
-          text_content: :normalize,
-          structural_whitespace: :ignore,
-        },
-        verbose: true,
-      )
-    rescue StandardError => e
-      return build_error_result(basename, "Compare", e)
-    end
+    compare_and_build_result(output[:xml], input[:xml], filepath, basename)
+  end
 
-    # Check result
+  def read_input(filepath, basename)
+    { xml: File.read(filepath) }
+  rescue StandardError => e
+    build_error_result(basename, "Read", e)
+  end
+
+  def parse_input(xml, basename)
+    { model: model_class_for(xml).from_xml(xml) }
+  rescue StandardError => e
+    build_error_result(basename, "Parse", e)
+  end
+
+  def serialize(model, basename)
+    { xml: model.to_xml(pretty: true, declaration: true, encoding: "utf-8") }
+  rescue StandardError => e
+    build_error_result(basename, "Serialize", e)
+  end
+
+  def model_class_for(xml)
+    root_element_name(xml) == "rfc-index" ? Rfcxml::RfcIndex::RfcIndex : Rfcxml::V3::Rfc
+  end
+
+  def compare_and_build_result(output, input, filepath, basename)
+    comparison = Canon::Comparison.equivalent?(
+      output, input,
+      diff_algorithm: :dom, format: :xml,
+      match: {
+        attribute_order: :ignore,
+        attribute_values: :normalize,
+        text_content: :normalize,
+        structural_whitespace: :ignore,
+      },
+      verbose: true
+    )
+    build_comparison_result(comparison, output, filepath, basename)
+  rescue StandardError => e
+    build_error_result(basename, "Compare", e)
+  end
+
+  def build_comparison_result(comparison, output, filepath, basename)
     equivalent = comparison.respond_to?(:equivalent?) ? comparison.equivalent? : comparison
+    return pass_result(basename) if equivalent
 
-    if equivalent
-      # Pass - write empty marker file
-      write_pass_marker(basename)
-      { file: basename, status: :pass }
-    else
-      # Fail - write detailed report and source
-      differences = extract_differences(comparison)
-      write_fail_report(basename, filepath, differences)
-      write_source_output(basename, output)
-      { file: basename, status: :fail, differences: differences }
-    end
+    differences = extract_differences(comparison)
+    write_fail_report(basename, filepath, differences)
+    write_source_output(basename, output)
+    { file: basename, status: :fail, differences: differences }
+  end
+
+  def pass_result(basename)
+    write_pass_marker(basename)
+    { file: basename, status: :pass }
   end
 
   def build_error_result(basename, phase, error)

--- a/spec/rfcxml/rfc_index/rfc_index_spec.rb
+++ b/spec/rfcxml/rfc_index/rfc_index_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Rfcxml::RfcIndex::RfcIndex do
+  let(:sample_xml) do
+    <<~XML
+      <?xml version='1.0' encoding='utf-8'?>
+      <rfc-index xmlns="https://www.rfc-editor.org/rfc-index" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://www.rfc-editor.org/rfc-index https://www.rfc-editor.org/rfc-index.xsd">
+        <bcp-entry>
+          <doc-id>BCP3</doc-id>
+          <is-also>
+            <doc-id>RFC1930</doc-id>
+          </is-also>
+        </bcp-entry>
+        <rfc-entry>
+          <doc-id>RFC1</doc-id>
+          <title>Host Software</title>
+          <author>
+            <name>S. Crocker</name>
+          </author>
+          <date>
+            <month>April</month>
+            <year>1969</year>
+          </date>
+          <format>
+            <file-format>TXT</file-format>
+            <file-format>HTML</file-format>
+          </format>
+          <page-count>11</page-count>
+          <abstract>
+            <p>Discusses host software.</p>
+          </abstract>
+          <obsoleted-by>
+            <doc-id>RFC28</doc-id>
+          </obsoleted-by>
+          <current-status>UNKNOWN</current-status>
+          <publication-status>UNKNOWN</publication-status>
+          <stream>Legacy</stream>
+          <doi>10.17487/RFC0001</doi>
+        </rfc-entry>
+        <std-entry>
+          <doc-id>STD3</doc-id>
+          <title>Host Requirements</title>
+          <is-also>
+            <doc-id>RFC1122</doc-id>
+            <doc-id>RFC1123</doc-id>
+          </is-also>
+        </std-entry>
+        <fyi-entry>
+          <doc-id>FYI3</doc-id>
+          <is-also>
+            <doc-id>RFC1175</doc-id>
+          </is-also>
+        </fyi-entry>
+        <rfc-not-issued-entry>
+          <doc-id>RFC14</doc-id>
+        </rfc-not-issued-entry>
+      </rfc-index>
+    XML
+  end
+
+  describe ".from_xml" do
+    subject(:parsed) { described_class.from_xml(sample_xml) }
+
+    it "parses all entry types" do
+      expect(parsed.bcp_entry.size).to eq(1)
+      expect(parsed.rfc_entry.size).to eq(1)
+      expect(parsed.std_entry.size).to eq(1)
+      expect(parsed.fyi_entry.size).to eq(1)
+      expect(parsed.rfc_not_issued_entry.size).to eq(1)
+    end
+
+    it "parses bcp-entry fields" do
+      bcp = parsed.bcp_entry.first
+      expect(bcp.doc_id).to eq("BCP3")
+      expect(bcp.is_also.doc_id).to eq(["RFC1930"])
+    end
+
+    it "parses rfc-entry metadata fields" do
+      rfc = parsed.rfc_entry.first
+      expect(rfc.doc_id).to eq("RFC1")
+      expect(rfc.title).to eq("Host Software")
+      expect(rfc.author.first.name).to eq("S. Crocker")
+      expect(rfc.date.month).to eq("April")
+      expect(rfc.date.year).to eq("1969")
+      expect(rfc.format.file_format).to eq(%w[TXT HTML])
+      expect(rfc.page_count).to eq("11")
+      expect(rfc.abstract.p).to eq(["Discusses host software."])
+    end
+
+    it "parses rfc-entry status fields" do
+      rfc = parsed.rfc_entry.first
+      expect(rfc.obsoleted_by.doc_id).to eq(["RFC28"])
+      expect(rfc.current_status).to eq("UNKNOWN")
+      expect(rfc.stream).to eq("Legacy")
+      expect(rfc.doi).to eq("10.17487/RFC0001")
+    end
+
+    it "parses std-entry fields" do
+      std = parsed.std_entry.first
+      expect(std.doc_id).to eq("STD3")
+      expect(std.title).to eq("Host Requirements")
+      expect(std.is_also.doc_id).to eq(%w[RFC1122 RFC1123])
+    end
+
+    it "parses fyi-entry fields" do
+      fyi = parsed.fyi_entry.first
+      expect(fyi.doc_id).to eq("FYI3")
+      expect(fyi.is_also.doc_id).to eq(["RFC1175"])
+    end
+
+    it "parses rfc-not-issued-entry fields" do
+      not_issued = parsed.rfc_not_issued_entry.first
+      expect(not_issued.doc_id).to eq("RFC14")
+    end
+  end
+
+  describe "#to_xml round-trip" do
+    it "preserves all data" do
+      parsed = described_class.from_xml(sample_xml)
+      output = parsed.to_xml(pretty: true, declaration: true,
+                             encoding: "utf-8")
+      reparsed = described_class.from_xml(output)
+
+      expect(reparsed.bcp_entry.size).to eq(1)
+      expect(reparsed.rfc_entry.size).to eq(1)
+      expect(reparsed.std_entry.size).to eq(1)
+      expect(reparsed.fyi_entry.size).to eq(1)
+      expect(reparsed.rfc_not_issued_entry.size).to eq(1)
+    end
+
+    it "is Canon-equivalent to the input" do
+      parsed = described_class.from_xml(sample_xml)
+      output = parsed.to_xml(pretty: true, declaration: true,
+                             encoding: "utf-8")
+      expect(output).to be_xml_equivalent_to(sample_xml)
+        .with_profile(:spec_friendly)
+    end
+  end
+
+  describe "default namespace handling" do
+    it "emits xmlns once on root" do
+      parsed = described_class.from_xml(sample_xml)
+      output = parsed.to_xml(pretty: true, declaration: true,
+                             encoding: "utf-8")
+      count = output.scan('xmlns="https://www.rfc-editor.org/rfc-index"').size
+      expect(count).to eq(1)
+    end
+
+    it "does not emit xmlns='' on children" do
+      parsed = described_class.from_xml(sample_xml)
+      output = parsed.to_xml(pretty: true, declaration: true,
+                             encoding: "utf-8")
+      expect(output).not_to include('xmlns=""')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `Rfcxml::RfcIndex` namespace that parses and serializes the [rfc-index.xml](https://www.rfc-editor.org/rfc-index.xml) document published by the RFC Editor. This document uses a separate schema (rfc-index.xsd) with its own default namespace and is distinct from RFC XML v3 documents.

Also fixes three round-trip failures that surfaced after switching the bulk download source to rsync.

## Changes

### New `Rfcxml::RfcIndex` module (`lib/rfcxml/rfc_index/`)

Models all five entry types per the official rfc-index.xsd:

- `RfcIndex` (root) — uses `ordered` to preserve document order across heterogeneous entry collections
- `RfcEntry` — uses `ordered` to preserve order of `is-also`/`obsoletes`/`updates`/`updated-by` (the actual rfc-index.xml puts `is-also` first, not in the schema's declared order)
- `StdEntry`, `BcpEntry`, `FyiEntry`, `RfcNotIssuedEntry`
- `Author`, `Date`, `Format`, `Keywords` + `Kw`, `Abstract`, `DocumentRef`
- `Namespace` (lutaml-model `XmlNamespace`) — default namespace with `element_form_default: :qualified` so children inherit it without repeated `xmlns` declarations

### Bug fixes

- **`lib/rfcxml/v3/artwork.rb`**: `src=""` and `originalSrc=""` were silently dropped during serialization. Added `value_map: { to: { empty: :empty } }` so empty string values are emitted as `attr=""`. Closes #27.

- **`lib/rfcxml/v3/dd.rb`**: `<dd>` was missing `blockquote` from its allowed children (per the upstream v3.rng schema), silently dropping `<blockquote>` children. Closes #28.

- **`lib/rfcxml/rfc_index/keywords.rb`**: `<kw></kw>` (empty kw element) was being dropped because `kw: :string, collection: true` skips empty strings. Refactored to use a dedicated `Kw` class so empty kw elements are preserved as `Kw.new(content: "")` instances.

### Round-trip test dispatch (`scripts/roundtrip_test.rb`)

Detects the root element and routes to the appropriate model:
- `<rfc-index>` → `Rfcxml::RfcIndex::RfcIndex`
- `<rfc>` → `Rfcxml::V3::Rfc`

Also refactored `perform_test` into smaller helpers for readability.

## Validation

- Full rfc-index.xml (9777 RFC entries + 245 BCP + 36 FYI + 93 STD + 188 not-issued, ~13 MB) round-trips Canon-equivalent.
- The two previously-failing v3 files (rfc9959.xml, rfc9972.xml) now pass.
- All 52 specs pass; RuboCop clean.

## Issues

Closes #27 (Artwork src emission)
Closes #28 (Dd missing blockquote)
Closes #29 (Add RfcIndex model)