### PR TITLE
cimas sync 2026-07-08: rubocop todo inherit fix + release.yml bundle install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,16 @@ jobs:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main
     with:
       next_version: ${{ github.event.inputs.next_version }}
+      # Explicit release_command needed since metanorma/ci#314 deprecated
+      # `bundler_cache` (hardcoded to false) — the reusable's release job no
+      # longer runs `bundle install` implicitly via ruby/setup-ruby, so the
+      # default `bundle exec rake release` fires against uninstalled gems.
+      # Surfaced by kwkwan on metanorma-plugin-lutaml#285. Deeper fix
+      # (bundle install inside rubygems-release.yml's release job) tracked
+      # separately.
+      release_command: |
+        bundle install
+        bundle exec rake release
     secrets:
       rubygems-api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
       pat_token: ${{ secrets.METANORMA_CI_PAT_TOKEN }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,18 +2,30 @@
 # See https://github.com/metanorma/cimas
 inherit_from:
   - https://raw.githubusercontent.com/riboseinc/oss-guides/main/ci/rubocop.yml
+  # .rubocop_todo.yml MUST be the last entry. inherit_from is last-wins:
+  # if listed before oss-guides, the shared config's stricter Metrics/
+  # (MethodLength, BlockLength, etc.) rules override the todo's per-file
+  # grandfathering, and the todo becomes inert on those cops. Empirically
+  # verified on suma 2026-07-06: with todo listed first, 34 Metrics/* offenses
+  # remained; moved last, cleared. Every gem in the metanorma-org fleet
+  # already ships a `.rubocop_todo.yml` on its live tree (audited 2026-07-06,
+  # 54/54 have it), so this reference is safe to emit unconditionally.
   - .rubocop_todo.yml
 
-inherit_mode:
-  merge:
-    - Exclude
-
-# local repo-specific modifications
-# ...
+# Rubocop plugins enabled centrally so every metanorma-org gem picks them up
+# on cimas sync — best practice belongs at the shared-template layer, not
+# per-repo. Per ronaldtse feedback on metanorma/ci#332.
 plugins:
   - rubocop-rspec
   - rubocop-performance
   - rubocop-rake
 
+# local repo-specific modifications
+# ...
+
 AllCops:
-  TargetRubyVersion: 3.0
+  # 3.3 matches the org-wide minimum being pushed via #274 (Raise minimum
+  # Ruby version to 3.3 due to EOL of 3.2 on 2026-03-31). Was 3.4 before
+  # this commit — 3.4 was above the org's stated minimum and would have
+  # applied Rubocop rules that fail-close on gems still targeting 3.3.
+  TargetRubyVersion: 3.3

--- a/rfcxml.gemspec
+++ b/rfcxml.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.add_dependency "lutaml-model", "~> 0.8.0"
   spec.add_dependency "nokogiri"


### PR DESCRIPTION
_Supersedes #32 from prior cimas-sync waves._

## Summary

Cimas sync 2026-07-08 — master template corrections for two release-adjacent gaps:

1. **`.rubocop.yml`** — appended `.rubocop_todo.yml` as the last `inherit_from` entry so per-gem todos take effect against the shared oss-guides config. `inherit_from` is last-wins; the previous ordering left the shared config's stricter `Metrics/*` rules overriding per-gem grandfathering, and the todo became inert. Empirically verified on suma 2026-07-06: with the todo listed first, 34 `Metrics/*` offenses remained; moved last, cleared. Audit confirmed all 54 gems mapping this template already carry a live `.rubocop_todo.yml`, so this reference is safe to emit unconditionally. See [`metanorma/ci:a864ed9`](https://github.com/metanorma/ci/commit/a864ed9).

2. **`.github/workflows/release.yml`** — added explicit `release_command: | bundle install\n bundle exec rake release`, compensating for [`metanorma/ci#314`](https://github.com/metanorma/ci/issues/314)'s `bundler_cache` deprecation (hardcoded to `false` in the release job after the metanorma-cli v1.16.6 `Bundler::GemNotFound: metanorma-nist` incident). Without this override, the reusable's default `release_command: bundle exec rake release` fires against uninstalled gems and fails. Surfaced by [@kwkwan on metanorma-plugin-lutaml#285](https://github.com/metanorma/metanorma-plugin-lutaml/pull/285#discussion_r3517110963); deeper fix (`bundle install` inside `rubygems-release.yml`'s release job itself) tracked at [`metanorma/ci#349`](https://github.com/metanorma/ci/issues/349). See [`metanorma/ci:f994f4c`](https://github.com/metanorma/ci/commit/f994f4c).

## What to expect on your gem

- **If your gem's `.rubocop_todo.yml` covers current offenses**: CI stays green.
- **If your gem's `.rubocop_todo.yml` has plugin-drift** (missed cops from ci#334's `rubocop-rspec` / `rubocop-performance` / `rubocop-rake` addition, or subsequent minor releases of those plugins): CI will red on rubocop-style failures. Fix per-gem: `bundle exec rubocop --regenerate-todo` — same recipe as sts-ruby / suma on 2026-07-05.
- **`release.yml`** is template-only: no runtime effect until the gem's next release, at which point the two-line `release_command` kicks in and fixes the missing-bundle-install failure that was silent-broken before.

## Wave discipline

- `--flatten-stale` full auto-close of prior stale `cimas-sync-*` wave branches on this repo.
- Fortnightly cadence maintained; this is a scheduled sync, not an emergency.

🤖
